### PR TITLE
Updated tim dependency definition. Corrected call of tim configure.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,8 @@ android {
 
 dependencies {
     //region TIM
-    debugImplementation "com.github.trifork:TIM-Android:1.5.0"
-    releaseImplementation "com.github.trifork:TIM-Android:1.5.0"
+    debugImplementation "com.github.trifork:tim-android:1.5.0"
+    releaseImplementation "com.github.trifork:tim-android:1.5.0"
     developmentImplementation project(':TIM-Android')
     //endregion
 

--- a/app/src/main/java/com/trifork/timandroid/util/TIMConfiguration.kt
+++ b/app/src/main/java/com/trifork/timandroid/util/TIMConfiguration.kt
@@ -26,7 +26,7 @@ fun configureTIM(context: Context): TIM {
         .description("My description")
         .build()
 
-    TIM.configure(timConfiguration, context = context, timBiometricData = timBiometricUtil)
+    TIM.configure(timConfiguration, null, context, timBiometricUtil, false)
 
     return TIM
 }


### PR DESCRIPTION
Fetching the TIM-Android dependency sometimes fails if the TIM-Android part is capitalised. I cannot currently build the example project without setting all the parameters on the new TIM.configure function implementation.

